### PR TITLE
Exclude the node_modules folder from being copied to target.

### DIFF
--- a/quali-t-app/build.sbt
+++ b/quali-t-app/build.sbt
@@ -24,6 +24,8 @@ libraryDependencies ++= Seq(
 //  "org.springframework"       %   "spring-tx"               % "4.1.6.RELEASE"
 )
 
+excludeFilter in Assets := "node_modules"
+
 // HEROKU sbt plugin
 herokuJdkVersion in Compile := "1.8"
 


### PR DESCRIPTION
This should prevent the node_modules folder from being copied to the target. It may look simple, but took me almost an hour to figure out... so don't feel bad!
